### PR TITLE
support preset languages during label resolving

### DIFF
--- a/app/helper/DefaultLabelResolver.java
+++ b/app/helper/DefaultLabelResolver.java
@@ -75,9 +75,11 @@ public class DefaultLabelResolver {
                 if (s.getObject() instanceof Literal) {
                     Literal literal = normalizeLiteral((Literal) s.getObject());
                     collectLabels.add(literal.stringValue());
+                    play.Logger.debug(literal.stringValue());
                     String label = getLabelInLanguage(literal, language);
-                    if (label != null)
+                    if (label != null) {
                         return label;
+                    }
                 }
             }
         } catch (Exception e) {

--- a/app/helper/EtikettMaker.java
+++ b/app/helper/EtikettMaker.java
@@ -242,7 +242,15 @@ public class EtikettMaker {
     }
 
     public static String lookUpLabel(String urlAddress) {
-        return lookUpLabel(urlAddress, null);
+        return lookUpLabel(urlAddress, getDefaultLanguage());
+    }
+
+    private static String getDefaultLanguage() {
+        String language = Play.application().configuration().getString("etikett.language");
+        if (language == null || language.isEmpty()) {
+            language = null;
+        }
+        return language;
     }
 
     public static String lookUpLabel(String urlAddress, String lang) {

--- a/app/helper/EtikettMaker.java
+++ b/app/helper/EtikettMaker.java
@@ -270,7 +270,6 @@ public class EtikettMaker {
                 || urlAddress.startsWith(CrossrefLabelResolver.id2)) {
             return CrossrefLabelResolver.lookup(urlAddress);
         }
-        play.Logger.debug("Use Default Resolver");
         String result = DefaultLabelResolver.lookup(urlAddress, lang);
         if (urlAddress.equals(result)) {
             result = TitleLabelResolver.lookup(urlAddress, lang);

--- a/app/helper/RdfUtils.java
+++ b/app/helper/RdfUtils.java
@@ -26,6 +26,9 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.LanguageHandler;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -33,6 +36,7 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 /**
  * @author Jan Schnasse schnasse@hbz-nrw.de
@@ -78,6 +82,20 @@ public class RdfUtils {
     public static Collection<Statement> readRdfToGraph(URL url, RDFFormat inf, String accept) throws IOException {
         try (InputStream in = URLUtil.urlToInputStream(url, URLUtil.mapOf("Accept", accept))) {
             return readRdfToGraph(in, inf, url.toString());
+        }
+    }
+
+    public static RepositoryConnection readRdfInputStreamToRepository(InputStream is, RDFFormat inf) {
+        RepositoryConnection con = null;
+        try {
+            Repository myRepository = new SailRepository(new MemoryStore());
+            myRepository.initialize();
+            con = myRepository.getConnection();
+            String baseURI = "";
+            con.add(is, baseURI, inf);
+            return con;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,6 +28,7 @@ etikett.admin-password="admin"
 etikett.imports=""
 etikett.alias.id="id"
 etikett.alias.type="type"
+etikett.language="de"
 
 http.port="9002"
 http.path="/tools/"


### PR DESCRIPTION
Bei mehrsprachigen SKOS-Einträgen wird aktuell kein Label angezeigt. Über setzen eines Eintrages in der application.conf `etikett.language` kann man eine bevorzugte Sprache setzen.